### PR TITLE
feature: allow vimwiki ctags filepath to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A vim plugin that enables improved querying of tags.
 
-Currently, this depends on [fzf.vim](https://github.com/junegunn/fzf.vim), but there are plans for a command that does not require it. 
+Currently, this depends on [fzf.vim](https://github.com/junegunn/fzf.vim), but there are plans for a command that does not require it.
 
-## Usage 
+## Usage
 
 This finds all locations with the tags `foo` and `bar`, but not `bazz`. It will put the results in a filterable `fzf` buffer with a preview of the file:
 
@@ -15,7 +15,7 @@ This finds all locations with the tags `foo` and `bar`, but not `bazz`. It will 
 An example binding:
 
 ```viml
-noremap <C-t> :FzfTagQuery 
+noremap <C-t> :FzfTagQuery
 ```
 
 ## Installation
@@ -26,3 +26,8 @@ Using [`vim-plug`](https://github.com/junegunn/vim-plug):
 Plug 'matt-snider/vim-tagquery', { 'do': 'bash install.sh' }
 ```
 
+## Configuration
+
+Path to the vimwiki ctags file:
+
+`let g:tagquery_ctags_file = '~/vimwiki/.vimwiki_tags'`

--- a/autoload/tagquery.vim
+++ b/autoload/tagquery.vim
@@ -5,7 +5,13 @@
 " ============================================================================
 let s:root = expand('<sfile>:p:h:h')
 let s:ctags_binary = 'ctags-query'
-let s:local_ctags_file = getcwd() . '/.tags'
+
+if exists('g:tagquery_ctags_file')
+    let s:local_ctags_file = g:tagquery_ctags_file
+else
+    let s:local_ctags_file = getcwd() . '/.tags'
+endif
+"echom 'xxxx:' s:local_ctags_file
 
 
 " Returns the path to the `ctags-query` binary
@@ -18,8 +24,9 @@ endfunction
 " a list of lines output by `ctags-query`.
 function! tagquery#execute_cli(query, ctags_path) abort
     let cmd = tagquery#binary_path() . ' '
-                \ . '-f' . a:ctags_path . ' '
+                \ . '-f ' . a:ctags_path . ' '
                 \ . shellescape(a:query)
+    "echom 'xxxx:' cmd
     let result = system(cmd)
     return split(result, '\n')
 endfunction

--- a/autoload/tagquery.vim
+++ b/autoload/tagquery.vim
@@ -26,7 +26,6 @@ function! tagquery#execute_cli(query, ctags_path) abort
     let cmd = tagquery#binary_path() . ' '
                 \ . '-f ' . a:ctags_path . ' '
                 \ . shellescape(a:query)
-    "echom 'xxxx:' cmd
     let result = system(cmd)
     return split(result, '\n')
 endfunction

--- a/autoload/tagquery.vim
+++ b/autoload/tagquery.vim
@@ -11,7 +11,6 @@ if exists('g:tagquery_ctags_file')
 else
     let s:local_ctags_file = getcwd() . '/.tags'
 endif
-"echom 'xxxx:' s:local_ctags_file
 
 
 " Returns the path to the `ctags-query` binary


### PR DESCRIPTION
Hi Matt, your hardcoded ctags path did not work for me. I made it configurable. 